### PR TITLE
Implement job type support, restructure GraphQL schema, and enhance admin job listing functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ src/generated/prisma/
 # Editor/IDE
 .vscode/
 .DS_Store
+
+# Uploaded files (user-generated content)
+src/uploads/

--- a/prisma/migrations/20250619093952_add_job_type/migration.sql
+++ b/prisma/migrations/20250619093952_add_job_type/migration.sql
@@ -1,0 +1,19 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Job" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "skillsRequired" JSONB NOT NULL,
+    "benefits" JSONB NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'OPEN',
+    "type" TEXT NOT NULL DEFAULT 'FULL_TIME',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+INSERT INTO "new_Job" ("benefits", "createdAt", "description", "id", "skillsRequired", "status", "title", "updatedAt") SELECT "benefits", "createdAt", "description", "id", "skillsRequired", "status", "title", "updatedAt" FROM "Job";
+DROP TABLE "Job";
+ALTER TABLE "new_Job" RENAME TO "Job";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,6 +21,12 @@ enum JobStatus {
   DRAFT
 }
 
+enum JobType {
+  FULL_TIME
+  PART_TIME
+  CONTRACT
+}
+
 model Admin {
   id String @id @default(uuid())
   email     String   @unique
@@ -37,6 +43,7 @@ model Job {
   skillsRequired Json
   benefits       Json
   status         JobStatus   @default(OPEN) // Replaces need for archived boolean
+  type           JobType    @default(FULL_TIME) 
   applicants     Applicant[]
   createdAt      DateTime    @default(now())
   updatedAt      DateTime    @updatedAt

--- a/src/graphql/modules/job/typeDefs.ts
+++ b/src/graphql/modules/job/typeDefs.ts
@@ -9,7 +9,13 @@ export const jobTypeDefs = gql`
     DRAFT
   }
 
-  type Job {
+  enum JobType {
+    FULL_TIME
+    PART_TIME
+    CONTRACT
+  }
+
+  type PublicJob {
     id: String!
     title: String!
     description: String!
@@ -17,24 +23,40 @@ export const jobTypeDefs = gql`
     skillsRequired: JSON!
     benefits: JSON!
     createdAt: String!
-    applicantCount: Int!
+  }
+
+  type AdminJob {
+    id: String!
+    title: String!
+    description: String!
+    status: JobStatus!
+    type: JobType!
+    applicants: Int!
+    createdAt: String!
   }
 
   input JobInput {
     title: String!
     description: String!
     status: JobStatus
+    type: JobType
     skillsRequired: JSON!
     benefits: JSON!
   }
 
   type Query {
-    jobs: [Job!]!
+    publicJobs: [PublicJob!]!
+    jobs(
+      search: String
+      status: JobStatus
+      skip: Int = 0
+      take: Int = 10
+    ): [AdminJob!]!
   }
 
   type Mutation {
-    createJob(input: JobInput!): Job!
-    updateJob(id: ID!, input: JobInput!): Job!
-    updateJobStatus(id: ID!, status: JobStatus!): Job!
+    createJob(input: JobInput!): AdminJob!
+    updateJob(id: ID!, input: JobInput!): AdminJob!
+    updateJobStatus(id: ID!, status: JobStatus!): AdminJob!
   }
 `;

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ const app = express();
 // ✅ CORS setup to allow frontend dev server access
 app.use(
     cors({
-        origin: 'http://localhost:3000', // your frontend origin
+        origin: ['http://localhost:3000', 'http://localhost:4000', 'https://studio.apollographql.com'], // your frontend origin
         credentials: true
     })
 );


### PR DESCRIPTION
**Summary**

This PR introduces major enhancements to the job model, GraphQL schema, and backend resolver logic to support a feature-rich admin job listing experience, along with necessary CORS and query fixes.

**Features & Enhancements**

**Schema and Database**
- **Added `JobType` enum** (`FULL_TIME`, `PART_TIME`, `CONTRACT`) to the Prisma schema
- Updated `Job` model to include `type` field with default value `FULL_TIME`
- Generated migration and synced Prisma client

**GraphQL Schema Updates**
- Defined separate types: `AdminJob` for the dashboard and `PublicJob` for the careers page
- Introduced two distinct queries:
  - `publicJobs` for unauthenticated users
  - `jobs` (admin-only) for dashboard listing with filtering support

**Resolver Refactor**
- `jobs` resolver now supports:
  - Full-text search on `title` and `description`
  - Enum-based filtering through free-text search for `status` and `type`
  - Explicit `status` filter when provided alongside search
  - Pagination via `skip` and `take`

**CORS & Introspection Fixes**
- Allowed `https://studio.apollographql.com` in CORS origins to enable Apollo Studio introspection
- Resolved preflight CORS errors when accessing Playground via Apollo Studio

**Access Control**
- `publicJobs` is exposed without authentication
- `jobs` remains protected via admin context check
