### PR TITLE
Implement searchable & filterable applicant listing for admin dashboard

### DIFF
--- a/src/graphql/modules/applicants/typeDefs.ts
+++ b/src/graphql/modules/applicants/typeDefs.ts
@@ -12,6 +12,15 @@ export const applicantTypeDefs = gql`
     REJECTED
   }
 
+  type ApplicantRow {
+    id: String!
+    name: String!
+    email: String!
+    stage: Stage!
+    position: String!
+    appliedAt: String!
+  }
+
   type Applicant {
     id: String!
     firstName: String!
@@ -33,6 +42,10 @@ export const applicantTypeDefs = gql`
     phone: String!
     jobId: String!
     message: String
+  }
+
+  extend type Query {
+    applicants(search: String, stage: Stage, skip: Int, take: Int): [ApplicantRow!]!
   }
 
   extend type Mutation {


### PR DESCRIPTION
This pull request introduces significant enhancements to the applicant listing query for the admin dashboard:

**Protected Query Added**: Introduced applicants admin-only query to list applicants.

**Enhanced Search Logic**:

- Search across firstName, lastName, email, phone, stage, and associated job.title.
- Stage filter works independently or alongside search query.

**Smart Filter Merging**: Supports dynamic OR + AND filtering without Prisma validation issues.

**Optimized Response:**

- Returns applicant id, name, email, stage, position (from job), and appliedAt.
- Includes pagination via skip and take.

**Catches Prisma Edge Cases**: Proper type guards and enum handling for stage filter.