### PR TITLE
Add totalApplicantsCount and totalJobsCount for pagination support

### DIFF
--- a/src/graphql/modules/applicants/typeDefs.ts
+++ b/src/graphql/modules/applicants/typeDefs.ts
@@ -1,4 +1,3 @@
-// src/modules/applicants/typeDefs.ts
 import { gql } from 'apollo-server';
 
 export const applicantTypeDefs = gql`
@@ -19,6 +18,11 @@ export const applicantTypeDefs = gql`
     stage: Stage!
     position: String!
     appliedAt: String!
+  }
+
+  type ApplicantsResponse {
+    applicants: [ApplicantRow!]!
+    totalApplicantsCount: Int!
   }
 
   type Applicant {
@@ -45,7 +49,7 @@ export const applicantTypeDefs = gql`
   }
 
   extend type Query {
-    applicants(search: String, stage: Stage, skip: Int, take: Int): [ApplicantRow!]!
+    applicants(search: String, stage: Stage, skip: Int, take: Int): ApplicantsResponse!
   }
 
   extend type Mutation {

--- a/src/graphql/modules/job/typeDefs.ts
+++ b/src/graphql/modules/job/typeDefs.ts
@@ -35,6 +35,11 @@ export const jobTypeDefs = gql`
     createdAt: String!
   }
 
+  type JobsResponse {
+    jobs: [AdminJob!]!
+    totalJobsCount: Int!
+  }
+
   input JobInput {
     title: String!
     description: String!
@@ -51,7 +56,7 @@ export const jobTypeDefs = gql`
       status: JobStatus
       skip: Int = 0
       take: Int = 10
-    ): [AdminJob!]!
+    ): JobsResponse!
   }
 
   type Mutation {


### PR DESCRIPTION
This PR implements pagination improvements by adding totalApplicantsCount and totalJobsCount to the GraphQL queries for both applicants and jobs, enabling proper pagination in the frontend.

**Applicant Pagination:** The applicants query now returns both the paginated applicant data and the total count of applicants (totalApplicantsCount) to support efficient pagination.

**Job Pagination:** The adminJobs query now includes totalJobsCount alongside the paginated job data, ensuring accurate pagination for job listings.

This change allows the frontend to calculate the total number of pages based on the count of applicants and jobs, improving the user experience when navigating large datasets.