### PR TITLE
Implement getJobById query for job detail retrieval

### DIFF
--- a/src/graphql/modules/job/resolvers.ts
+++ b/src/graphql/modules/job/resolvers.ts
@@ -95,8 +95,40 @@ export const jobResolvers = {
                 console.error('Error fetching jobs:', error);
                 throw new Error('Internal Server Error');
             }
-        }
+        },
 
+        // Fetch single job by ID
+        getJobById: async (
+            _: unknown,
+            { id }: { id: string },
+            { prisma }: { prisma: PrismaClient }
+        ) => {
+            try {
+                const job = await prisma.job.findUnique({
+                    where: { id },
+                    include: { applicants: true }, // Include applicants count if needed
+                });
+
+                if (!job) {
+                    throw new UserInputError(`Job with ID ${id} not found`);
+                }
+
+                return {
+                    id: job.id,
+                    title: job.title,
+                    description: job.description,
+                    status: job.status,
+                    type: job.type,
+                    skillsRequired: job.skillsRequired, // Array of strings
+                    benefits: job.benefits, // Array of strings
+                    createdAt: job.createdAt.toISOString(),
+                    applicants: job.applicants.length,
+                };
+            } catch (error) {
+                console.error('Error fetching job by ID:', error);
+                throw new Error('Internal Server Error');
+            }
+        },
     },
 
     Mutation: {

--- a/src/graphql/modules/job/typeDefs.ts
+++ b/src/graphql/modules/job/typeDefs.ts
@@ -35,6 +35,18 @@ export const jobTypeDefs = gql`
     createdAt: String!
   }
 
+  type Job {
+    id: String!
+    title: String!
+    description: String!
+    status: JobStatus!
+    type: JobType!
+    skillsRequired: JSON!
+    benefits: JSON!
+    createdAt: String!
+    applicants: Int!
+  }
+
   type JobsResponse {
     jobs: [AdminJob!]!
     totalJobsCount: Int!
@@ -57,6 +69,8 @@ export const jobTypeDefs = gql`
       skip: Int = 0
       take: Int = 10
     ): JobsResponse!
+    getJobById(id: String!): Job! 
+
   }
 
   type Mutation {


### PR DESCRIPTION
This PR introduces the `getJobById` GraphQL query for fetching detailed job data by ID.
