### PR TITLE
Implement updateApplicantStage mutation with validation

### DIFF
--- a/src/graphql/modules/applicants/resolvers.ts
+++ b/src/graphql/modules/applicants/resolvers.ts
@@ -167,6 +167,25 @@ export const applicantResolvers = {
             });
 
             return applicant;
+        },
+        updateApplicantStage: async (
+            _: unknown,
+            args: { id: string; stage: string },
+            { prisma }: { prisma: PrismaClient }
+        ) => {
+            const VALID_STAGES = ['APPLIED', 'SHORTLISTED', 'INTERVIEWED', 'HIRED', 'REJECTED'];
+
+            if (!VALID_STAGES.includes(args.stage)) {
+                throw new UserInputError('Invalid stage value');
+            }
+
+            const updated = await prisma.applicant.update({
+                where: { id: args.id },
+                data: { stage: args.stage }
+            });
+
+            return updated;
         }
+
     }
 };

--- a/src/graphql/modules/applicants/typeDefs.ts
+++ b/src/graphql/modules/applicants/typeDefs.ts
@@ -62,5 +62,7 @@ export const applicantTypeDefs = gql`
 
   extend type Mutation {
     submitApplicationText(input: ApplicantTextInput!, cv: Upload!, coverLetter: Upload!): Applicant!
+    updateApplicantStage(id: String!, stage: Stage!): Applicant!
+
   }
 `;


### PR DESCRIPTION
**Summary**

Introduces a new GraphQL mutation to update an applicant's stage. Enables admin users to modify applicant progression directly from the frontend interface.

**Changes**

- Added `updateApplicantStage` mutation to GraphQL schema
- Mutation accepts:
  - `id: String!`
  - `stage: Stage!`
- Stage is validated against the allowed enum values:
  - APPLIED, SHORTLISTED, INTERVIEWED, HIRED, REJECTED
- Returns updated `Applicant` object
