### PR TITLE
Add backend support for dashboard KPIs and monthly job/applicant trends

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@prisma/client": "^6.9.0",
         "apollo-server": "^3.13.0",
         "bcrypt": "^6.0.0",
+        "date-fns": "^4.1.0",
         "dotenv": "^16.5.0",
         "graphql": "^16.11.0",
         "graphql-type-json": "^0.3.2",
@@ -1388,6 +1389,16 @@
       "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
       "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==",
       "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/debug": {
       "version": "2.6.9",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@prisma/client": "^6.9.0",
     "apollo-server": "^3.13.0",
     "bcrypt": "^6.0.0",
+    "date-fns": "^4.1.0",
     "dotenv": "^16.5.0",
     "graphql": "^16.11.0",
     "graphql-type-json": "^0.3.2",

--- a/src/graphql/modules/analytics/resolvers.ts
+++ b/src/graphql/modules/analytics/resolvers.ts
@@ -1,0 +1,74 @@
+import { PrismaClient } from '@prisma/client';
+import { startOfMonth, endOfMonth, subMonths, format } from 'date-fns';
+
+const prisma = new PrismaClient();
+
+export const analyticsResolvers = {
+    Query: {
+        dashboardStats: async () => {
+            const activeJobs = await prisma.job.count({ where: { status: 'OPEN' } });
+
+            const totalApplicants = await prisma.applicant.count();
+
+            const shortlistedCount = await prisma.applicant.count({
+                where: { stage: 'SHORTLISTED' },
+            });
+
+            const top = await prisma.applicant.groupBy({
+                by: ['jobId'],
+                _count: { jobId: true },
+                orderBy: { _count: { jobId: 'desc' } },
+                take: 1,
+            });
+
+            let topJobStr = 'N/A';
+            if (top.length > 0) {
+                const job = await prisma.job.findUnique({ where: { id: top[0].jobId } });
+                topJobStr = `${job?.title || 'Unknown'} – ${top[0]._count.jobId} Applications`;
+            }
+
+            return {
+                activeJobs,
+                totalApplicants,
+                shortlistedCount,
+                topJob: topJobStr,
+            };
+        },
+
+        monthlyTrends: async () => {
+            const now = new Date();
+            const months = Array.from({ length: 6 }, (_, i) => subMonths(now, 5 - i));
+
+            const result = await Promise.all(
+                months.map(async (date) => {
+                    const start = startOfMonth(date);
+                    const end = endOfMonth(date);
+                    const month = format(date, 'MMM');
+
+                    const jobs = await prisma.job.count({
+                        where: {
+                            createdAt: { gte: start, lte: end },
+                        },
+                    });
+
+                    const applicants = await prisma.applicant.count({
+                        where: {
+                            appliedAt: { gte: start, lte: end },
+                        },
+                    });
+
+                    const hired = await prisma.applicant.count({
+                        where: {
+                            appliedAt: { gte: start, lte: end },
+                            stage: 'HIRED',
+                        },
+                    });
+
+                    return { month, jobs, applicants, hired };
+                })
+            );
+
+            return result;
+        },
+    },
+};

--- a/src/graphql/modules/analytics/typeDefs.ts
+++ b/src/graphql/modules/analytics/typeDefs.ts
@@ -1,0 +1,22 @@
+import { gql } from 'apollo-server';
+
+export const analyticsTypeDefs = gql`
+  type DashboardStats {
+    activeJobs: Int!
+    totalApplicants: Int!
+    topJob: String!
+    shortlistedCount: Int!
+  }
+
+  type MonthlyStats {
+    month: String!
+    jobs: Int!
+    applicants: Int!
+    hired: Int!
+  }
+
+  extend type Query {
+    dashboardStats: DashboardStats!
+    monthlyTrends: [MonthlyStats!]!
+  }
+`;

--- a/src/graphql/modules/index.ts
+++ b/src/graphql/modules/index.ts
@@ -9,6 +9,8 @@ import { jobResolvers } from './job/resolvers';
 import { applicantTypeDefs } from './applicants/typeDefs';
 import { applicantResolvers } from './applicants/resolvers';
 
+import { analyticsTypeDefs } from './analytics/typeDefs';
+import { analyticsResolvers } from './analytics/resolvers';
 
-export const typeDefs = mergeTypeDefs([authTypeDefs, jobTypeDefs, applicantTypeDefs]);
-export const resolvers = mergeResolvers([authResolvers, jobResolvers, applicantResolvers]);
+export const typeDefs = mergeTypeDefs([authTypeDefs, jobTypeDefs, applicantTypeDefs, analyticsTypeDefs]);
+export const resolvers = mergeResolvers([authResolvers, jobResolvers, applicantResolvers, analyticsResolvers]);


### PR DESCRIPTION
**Summary**

Introduces a new backend analytics module providing dashboard-level insights for admin users, including job and applicant metrics.
**Added**

- `dashboardStats` query:
  - `activeJobs`: count of currently open jobs
  - `totalApplicants`: total applicants across all jobs
  - `topJob`: job with highest number of applicants
  - `shortlistedCount`: count of applicants in SHORTLISTED stage

- `monthlyTrends` query:
  - Returns last 6 months of:
    - jobs posted
    - applicants received
    - hires made