### PR TITLE
Relay warning on applicant stage update

### DIFF
--- a/src/graphql/modules/applicants/resolvers.ts
+++ b/src/graphql/modules/applicants/resolvers.ts
@@ -70,7 +70,7 @@ export const applicantResolvers = {
                 // Return both the paginated applicants and total count in the expected format
                 return {
                     applicants: applicants.map((app) => ({
-                        id: app.id,
+                        id: `applicant-${app.id}`,
                         name: `${app.firstName} ${app.lastName}`,
                         email: app.email,
                         stage: app.stage,
@@ -92,7 +92,6 @@ export const applicantResolvers = {
             if (!admin) throw new AuthenticationError('Only Admin can Access');
 
             const applicantId = id.replace(/^applicant-/, '');
-            console.log(`Querying for applicant with id: ${applicantId}`);
 
             const applicant = await prisma.applicant.findUnique({
                 where: { id: applicantId },
@@ -106,7 +105,7 @@ export const applicantResolvers = {
             }
 
             return {
-                __typename: 'Applicant',  // Use 'Applicant' for detail view
+                __typename: 'Applicant',
                 id: `applicant-${applicant.id}`,
                 firstName: applicant.firstName,
                 lastName: applicant.lastName,
@@ -156,7 +155,6 @@ export const applicantResolvers = {
                 const stream = createReadStream();
                 const uniqueName = `${prefix}-${uuidv4()}${path.extname(filename)}`;
                 const uploadPath = path.join(process.cwd(), 'uploads');
-                console.log('uploadPath', uploadPath)
                 const filePath = path.join(uploadPath, uniqueName);
 
                 // Ensure uploads folder exists (optional but safe)

--- a/src/graphql/modules/applicants/typeDefs.ts
+++ b/src/graphql/modules/applicants/typeDefs.ts
@@ -62,7 +62,7 @@ export const applicantTypeDefs = gql`
 
   extend type Mutation {
     submitApplicationText(input: ApplicantTextInput!, cv: Upload!, coverLetter: Upload!): Applicant!
-    updateApplicantStage(id: ID!, stage: Stage!): Applicant!
+    updateApplicantStage(id: ID!, stage: Stage!): ApplicantRow!
 
   }
 `;

--- a/src/graphql/modules/job/job.test.ts
+++ b/src/graphql/modules/job/job.test.ts
@@ -146,7 +146,6 @@ describe('Job Module Tests', () => {
                 query: GET_JOB_BY_ID,
                 variables: { id: '1' }
             });
-        console.log('res of get job by ID', res.body)
         expect(res.status).toBe(200);
         expect(res.body.data.getJobById.title).toBe('Job 1');
     });

--- a/src/graphql/modules/job/resolvers.ts
+++ b/src/graphql/modules/job/resolvers.ts
@@ -121,7 +121,6 @@ export const jobResolvers = {
 
             try {
                 const jobId = id.replace(/^job-|^admin-job-/, '');  // Strip prefix
-                console.log(`Querying for job with id: ${jobId}`);
 
                 const job = await prisma.job.findUnique({
                     where: { id: jobId },
@@ -249,9 +248,7 @@ export const jobResolvers = {
             { prisma, admin }: { prisma: PrismaClient; admin?: { adminId: string } }
         ) => {
             if (!admin) throw new AuthenticationError('Only admins can update job status');
-            console.log('id in job', id)
             const jobId = id.replace(/^job-|^admin-job-/, '');  // Strip prefix
-            console.log('after prefix', jobId)
             const existing = await prisma.job.findUnique({
                 where: { id: jobId },
                 include: { applicants: true }


### PR DESCRIPTION
This PR has fix for the following issue:

Relay was throwing a __typename inconsistency error when fetching applicants because both ApplicantRow (from the applicants query) and Applicant (from the getApplicantById query) used the same id format.