### PR TITLE
Implement Relay Cursor-Based Pagination for Public Jobs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "date-fns": "^4.1.0",
         "dotenv": "^16.5.0",
         "graphql": "^16.11.0",
+        "graphql-relay": "^0.10.2",
         "graphql-type-json": "^0.3.2",
         "graphql-upload": "^13.0.0",
         "jsonwebtoken": "^9.0.2",
@@ -5789,6 +5790,18 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/graphql-relay": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/graphql-relay/-/graphql-relay-0.10.2.tgz",
+      "integrity": "sha512-abybva1hmlNt7Y9pMpAzHuFnM2Mme/a2Usd8S4X27fNteLGRAECMYfhmsrpZFvGn3BhmBZugMXYW/Mesv3P1Kw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.15.0 || >= 15.9.0"
+      },
+      "peerDependencies": {
+        "graphql": "^16.2.0"
       }
     },
     "node_modules/graphql-tag": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "date-fns": "^4.1.0",
     "dotenv": "^16.5.0",
     "graphql": "^16.11.0",
+    "graphql-relay": "^0.10.2",
     "graphql-type-json": "^0.3.2",
     "graphql-upload": "^13.0.0",
     "jsonwebtoken": "^9.0.2",

--- a/src/graphql/modules/job/typeDefs.ts
+++ b/src/graphql/modules/job/typeDefs.ts
@@ -33,6 +33,23 @@ export const jobTypeDefs = gql`
     totalJobsCount: Int!
   }
 
+  type JobEdge {
+   cursor: String!
+   node: Job!
+  }
+
+  type JobConnection {
+    edges: [JobEdge!]!
+    pageInfo: PageInfo!
+  }
+
+  type PageInfo {
+    hasNextPage: Boolean!
+    hasPreviousPage: Boolean!
+    startCursor: String
+    endCursor: String
+  }
+
   input JobInput {
     title: String!
     description: String!
@@ -43,7 +60,7 @@ export const jobTypeDefs = gql`
   }
 
   type Query {
-    publicJobs: [Job!]!
+    publicJobs(first: Int, after: String): JobConnection!
     jobs(
       search: String
       status: JobStatus


### PR DESCRIPTION
This PR refactors the public jobs page to use Relay-style cursor-based pagination. Instead of rendering all jobs at once in a carousel, it now loads an initial batch (6 jobs).

- Updated backend resolver and schema to support Relay pagination spec

